### PR TITLE
Add QEMU-based ISO boot & scripted-install test harness

### DIFF
--- a/.github/workflows/iso-test.yml
+++ b/.github/workflows/iso-test.yml
@@ -1,0 +1,47 @@
+# Build the ISO and verify it boots + installs, all in QEMU.
+#
+# Manual-trigger only for now (workflow_dispatch). When you're happy with it,
+# add the push triggers you want, e.g.:
+#   on:
+#     push:
+#       branches: [develop, main]
+#
+# Requires a runner with /dev/kvm for reasonable speed. The harness falls back
+# to slow TCG emulation if KVM is absent, so it still passes without it.
+name: Mika ISO boot & install test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    # Reuses the self-hosted Arch runner from main.yml. To run on a
+    # GitHub-hosted box instead, swap this for `runs-on: ubuntu-latest` and run
+    # the build/test steps inside a privileged `archlinux:latest` container.
+    runs-on:
+      - self-hosted
+      - Arch
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install test dependencies
+        run: sudo pacman -Sy --needed --noconfirm archiso qemu-base edk2-ovmf libisoburn python
+
+      - name: Build the ISO
+        run: sudo mkarchiso -v -w /tmp/archiso-tmp -o out .
+
+      - name: Boot smoke test (BIOS + UEFI)
+        run: scripts/test/boot-test.sh both
+
+      - name: Scripted install test (UEFI)
+        run: scripts/test/install-test.sh uefi
+
+      - name: Upload ISO artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mika-iso
+          path: out/*.iso
+          if-no-files-found: warn

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -1,0 +1,77 @@
+# Mika ISO test harness
+
+Build → boot → install, all in QEMU, with no USB stick and no test laptop.
+The goal: on every push, prove that a change still produces an ISO that
+**boots** and **installs into a system that itself boots** — in both BIOS and
+UEFI mode.
+
+Everything here is plain `bash` + `qemu`, so the exact same scripts run on a
+developer machine and on any CI runner.
+
+## What's here
+
+| Script | Stage | What it proves |
+|--------|-------|----------------|
+| `run.sh` | — | Interactive boot of the ISO in a QEMU window (manual poke-around). |
+| `boot-test.sh` | Boot smoke | The ISO boots headless (BIOS+UEFI) and the live env comes up. |
+| `install-test.sh` | Install + post-install | A scripted install onto a blank disk succeeds, and the **installed** disk boots to a login prompt. |
+| `payloads/selftest.sh` | — | Runs inside the live ISO; prints `MIKA_BOOT_OK`. |
+| `payloads/install.sh` | — | Runs inside the live ISO; partitions, copies the rootfs, installs GRUB, prints `MIKA_INSTALL_OK`. |
+| `lib.sh` | — | Shared helpers (sourced, not run). |
+
+## How it works
+
+1. **Build** the ISO as usual (`sudo mkarchiso -v .`) — output lands in `out/`.
+2. The harness extracts the kernel + initramfs from the ISO and boots them
+   with `-kernel/-initrd/-append`, because archiso sets its cmdline from the
+   bootloader *inside* the ISO and we need to inject `script=`. archiso locates
+   its squashfs via `archisolabel=` (read from the ISO with `blkid`).
+3. The `script=<url>` cmdline triggers the ISO's existing
+   `/root/.automated_script.sh`, which downloads and runs a **payload** from a
+   throwaway HTTP server on the host (reachable from the guest at `10.0.2.2`).
+   This keeps all test code **out of the production ISO**.
+4. Payloads echo their result markers to `/dev/ttyS0`, which the harness
+   captures as the headless serial log and greps for the marker.
+
+## Run it locally
+
+Prereqs (Arch): `sudo pacman -S qemu-desktop edk2-ovmf xorriso python`
+KVM (`/dev/kvm`) is used automatically when present; without it QEMU falls back
+to slow TCG emulation, so the scripts still work in a plain container.
+
+```bash
+# after a build:
+scripts/test/boot-test.sh            # BIOS + UEFI smoke test
+scripts/test/boot-test.sh uefi       # just UEFI
+scripts/test/install-test.sh uefi    # scripted install + boot the result
+scripts/test/run.sh uefi             # open it in a window and click around
+```
+
+Point at a specific ISO with `ISO=/path/to/x.iso scripts/test/boot-test.sh`.
+Tunables (env vars): `VM_MEM`, `VM_SMP`, `DISK_SIZE`, `BOOT_TIMEOUT`,
+`INSTALL_TIMEOUT`, `POSTINSTALL_TIMEOUT`.
+
+## CI wiring (decide later — both options work)
+
+The scripts are runner-agnostic; the only requirement for *fast* runs is
+access to `/dev/kvm`. A starting workflow lives at
+`.github/workflows/iso-test.yml` (manual `workflow_dispatch` for now so it
+doesn't fire unexpectedly). Two ways to host it:
+
+* **Self-hosted Arch runner** (you already have one in `main.yml`): build with
+  `mkarchiso`, then run the harness directly. Make sure the runner user can
+  read/write `/dev/kvm` (add it to the `kvm` group) for speed.
+* **GitHub-hosted `ubuntu-latest`**: run `mkarchiso` inside a privileged
+  `archlinux:latest` container, then run the harness. GitHub's larger Linux
+  runners expose nested KVM; on standard runners it falls back to TCG (slow but
+  green).
+
+## Known sticking points (validate on first real run)
+
+This harness was written from the repo layout; the **live-rootfs → installed**
+conversion in `payloads/install.sh` is the part most likely to need tuning the
+first time, because turning an archiso live root into a bootable installed
+system has edge cases (initramfs hooks, GRUB target, fstab). The boot smoke
+test is the simpler, higher-confidence gate; treat the install test as the
+piece to iterate on. If a stage fails, the harness dumps the last 40 lines of
+the guest serial log to help diagnose.

--- a/scripts/test/boot-test.sh
+++ b/scripts/test/boot-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Stage 2 — Boot smoke test.
+#
+# Boots the built ISO headless in QEMU (BIOS and/or UEFI) using the extracted
+# kernel + the `script=` hook, and asserts the live environment reaches our
+# self-test payload, which echoes MIKA_BOOT_OK to the serial console.
+#
+# Usage:
+#   scripts/test/boot-test.sh [bios|uefi|both]      (default: both)
+#   ISO=/path/to/x.iso scripts/test/boot-test.sh
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require qemu-system-x86_64 blkid xorriso
+
+MODE="${1:-both}"
+log "ISO under test: $(find_iso)"
+
+start_payload_server
+trap stop_payload_server EXIT
+
+boot_once() {
+    local fw="$1" logfile
+    logfile="$(mktemp --suffix=-mika-boot-${fw}.log)"
+    boot_iso_with_payload "$fw" "$BOOT_TIMEOUT" "$logfile" "selftest.sh"
+    expect_sentinel "$logfile" "MIKA_BOOT_OK" "live environment booted (${fw})"
+}
+
+rc=0
+case "$MODE" in
+    bios) boot_once bios || rc=1 ;;
+    uefi) boot_once uefi || rc=1 ;;
+    both) boot_once bios || rc=1; boot_once uefi || rc=1 ;;
+    *)    fail "usage: $0 [bios|uefi|both]" ;;
+esac
+
+[[ $rc -eq 0 ]] && ok "boot smoke test passed (${MODE})"
+exit $rc

--- a/scripts/test/install-test.sh
+++ b/scripts/test/install-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Stage 3 + 4 — Scripted install, then boot the installed disk.
+#
+# 1. Creates a fresh blank qcow2 disk.
+# 2. Boots the ISO with the install payload, which partitions that disk,
+#    copies the live system onto it (the way Calamares' unpackfs does),
+#    installs GRUB, and powers off. It echoes MIKA_INSTALL_OK on success.
+# 3. Boots the *installed* disk (no ISO) and asserts it reaches a login
+#    prompt on the serial console (MIKA_POSTINSTALL via login: marker).
+#
+# Usage:
+#   scripts/test/install-test.sh [bios|uefi]        (default: uefi)
+#   ISO=/path/to/x.iso scripts/test/install-test.sh
+#
+# NOTE: converting a live archiso rootfs into a bootable installed system has
+# real edge cases (initramfs hooks, bootloader, fstab). The payload models
+# what Calamares does, but expect to tune payloads/install.sh against a real
+# build the first time through.
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require qemu-system-x86_64 qemu-img blkid xorriso
+
+FW="${1:-uefi}"
+[[ "$FW" == bios || "$FW" == uefi ]] || fail "usage: $0 [bios|uefi]"
+
+log "ISO under test: $(find_iso)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+DISK="${WORK}/mika-install.qcow2"
+qemu-img create -f qcow2 "$DISK" "$DISK_SIZE" >/dev/null
+log "created blank target disk (${DISK_SIZE})"
+
+start_payload_server
+trap 'stop_payload_server; rm -rf "$WORK"' EXIT
+
+# --- Stage 3: run the scripted install ------------------------------------
+install_log="$(mktemp --suffix=-mika-install.log)"
+log "running scripted install (${FW})..."
+boot_iso_with_payload "$FW" "$INSTALL_TIMEOUT" "$install_log" "install.sh" \
+    -drive "file=${DISK},if=virtio,format=qcow2"
+expect_sentinel "$install_log" "MIKA_INSTALL_OK" "scripted install completed (${FW})"
+
+# --- Stage 4: boot the installed disk -------------------------------------
+post_log="$(mktemp --suffix=-mika-postinstall.log)"
+log "booting installed disk (${FW})..."
+boot_disk "$FW" "$POSTINSTALL_TIMEOUT" "$post_log" "$DISK"
+# A serial-getty login prompt is the proof the installed system boots.
+expect_sentinel "$post_log" "login:" "installed system reached login prompt (${FW})"
+
+ok "install test passed (${FW})"

--- a/scripts/test/lib.sh
+++ b/scripts/test/lib.sh
@@ -1,0 +1,215 @@
+# shellcheck shell=bash
+#
+# Shared helpers for the Mika ISO test harness.
+#
+# Source this file, don't execute it:
+#     source "$(dirname "$0")/lib.sh"
+#
+# Design notes (why it works the way it does):
+#
+#  * Runner-agnostic. Needs only bash, qemu, util-linux (blkid), python3 and
+#    — for UEFI — edk2-ovmf. Identical behaviour on a laptop and in CI. KVM is
+#    used when /dev/kvm is present and falls back to slow TCG otherwise.
+#
+#  * Booting the ISO. archiso sets the kernel cmdline from the bootloader
+#    INSIDE the ISO, so we cannot inject `script=` through QEMU's -append while
+#    booting the CD directly. Instead we extract vmlinuz + initramfs (+ucode)
+#    from the ISO and boot them with `-kernel/-initrd/-append`, the way the
+#    archiso wiki documents headless QEMU testing. archiso finds its squashfs
+#    via `archisolabel=<LABEL>` (read from the ISO with blkid), so no UUID is
+#    needed.
+#
+#  * Running a script in the guest. The live ISO's /root/.automated_script.sh
+#    already executes `script=<url>` from the cmdline — but ONLY on tty1, and
+#    its output goes to tty1. We serve the payload over HTTP (reachable from
+#    the guest at 10.0.2.2) and the payload echoes its result to /dev/ttyS0 so
+#    the headless serial log captures it. This keeps all test code OUT of the
+#    production ISO.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${TEST_DIR}/../.." && pwd)"
+PAYLOAD_DIR="${TEST_DIR}/payloads"
+
+# Tunables (override via environment).
+VM_MEM="${VM_MEM:-4096}"
+VM_SMP="${VM_SMP:-2}"
+DISK_SIZE="${DISK_SIZE:-20G}"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-300}"          # reach the live boot sentinel
+INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-1800}"   # full scripted install
+POSTINSTALL_TIMEOUT="${POSTINSTALL_TIMEOUT:-300}" # boot the installed disk
+
+# ----------------------------------------------------------------------------
+# Logging
+# ----------------------------------------------------------------------------
+log()  { printf '\033[1;34m[test]\033[0m %s\n' "$*" >&2; }
+ok()   { printf '\033[1;32m[ ok ]\033[0m %s\n' "$*" >&2; }
+fail() { printf '\033[1;31m[fail]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ----------------------------------------------------------------------------
+# Dependencies & assets
+# ----------------------------------------------------------------------------
+require() {
+    local missing=0 cmd
+    for cmd in "$@"; do
+        command -v "$cmd" >/dev/null 2>&1 || { log "missing command: $cmd"; missing=1; }
+    done
+    [[ $missing -eq 0 ]] || fail "install the missing dependencies and retry"
+}
+
+# Locate the built ISO ($ISO override, else newest out/*.iso).
+find_iso() {
+    if [[ -n "${ISO:-}" ]]; then
+        [[ -f "$ISO" ]] || fail "ISO=$ISO does not exist"
+        printf '%s\n' "$ISO"; return
+    fi
+    local found
+    found="$(ls -t "${REPO_ROOT}/out/"*.iso 2>/dev/null | head -n1 || true)"
+    [[ -n "$found" ]] || fail "no ISO in ${REPO_ROOT}/out/ — build it first or set ISO=..."
+    printf '%s\n' "$found"
+}
+
+# Read the ISO9660 volume label archiso matches on.
+iso_label() {
+    local label
+    label="$(blkid -s LABEL -o value "$1" 2>/dev/null || true)"
+    [[ -n "$label" ]] || fail "could not read volume label from $1"
+    printf '%s\n' "$label"
+}
+
+# Extract the boot bits from the ISO into $1 (dir). Echoes nothing; sets
+# globals KERNEL and INITRD (comma-joined: ucode first, then initramfs).
+KERNEL=""; INITRD=""
+extract_iso_boot() {
+    local iso="$1" dest="$2"
+    require xorriso
+    mkdir -p "$dest"
+    # install_dir is "arch" (profiledef.sh). Extract kernel + any microcode +
+    # the main initramfs.
+    local base="/arch/boot"
+    xorriso -osirrox on -indev "$iso" \
+        -extract "${base}/x86_64/vmlinuz-linux"     "${dest}/vmlinuz-linux" \
+        -extract "${base}/x86_64/initramfs-linux.img" "${dest}/initramfs-linux.img" \
+        >/dev/null 2>&1 || fail "failed to extract kernel/initramfs from $iso"
+    KERNEL="${dest}/vmlinuz-linux"
+    local initrds=()
+    local uc
+    for uc in intel-ucode.img amd-ucode.img; do
+        if xorriso -osirrox on -indev "$iso" \
+              -extract "${base}/${uc}" "${dest}/${uc}" >/dev/null 2>&1; then
+            initrds+=("${dest}/${uc}")
+        fi
+    done
+    initrds+=("${dest}/initramfs-linux.img")
+    INITRD="$(IFS=,; echo "${initrds[*]}")"
+}
+
+accel_args() {
+    if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+        printf '%s\n' "-enable-kvm -cpu host"
+    else
+        log "/dev/kvm unavailable — using slow TCG emulation"
+        printf '%s\n' "-cpu max"
+    fi
+}
+
+find_ovmf_code() {
+    local c
+    for c in /usr/share/edk2/x64/OVMF_CODE.4m.fd /usr/share/edk2/x64/OVMF_CODE.fd \
+             /usr/share/edk2-ovmf/x64/OVMF_CODE.fd \
+             /usr/share/OVMF/OVMF_CODE.4m.fd /usr/share/OVMF/OVMF_CODE.fd; do
+        [[ -f "$c" ]] && { printf '%s\n' "$c"; return; }
+    done
+    fail "OVMF code not found — install edk2-ovmf (Arch) / ovmf (Debian)"
+}
+find_ovmf_vars_template() {
+    local v
+    for v in /usr/share/edk2/x64/OVMF_VARS.4m.fd /usr/share/edk2/x64/OVMF_VARS.fd \
+             /usr/share/edk2-ovmf/x64/OVMF_VARS.fd \
+             /usr/share/OVMF/OVMF_VARS.4m.fd /usr/share/OVMF/OVMF_VARS.fd; do
+        [[ -f "$v" ]] && { printf '%s\n' "$v"; return; }
+    done
+    fail "OVMF vars template not found — install edk2-ovmf / ovmf"
+}
+
+# ----------------------------------------------------------------------------
+# Payload HTTP server (guest reaches host at 10.0.2.2)
+# ----------------------------------------------------------------------------
+HTTP_PID=""; HTTP_PORT=""
+start_payload_server() {
+    require python3
+    HTTP_PORT="$(( (RANDOM % 20000) + 20000 ))"
+    ( cd "$PAYLOAD_DIR" && exec python3 -m http.server "$HTTP_PORT" --bind 127.0.0.1 ) \
+        >/dev/null 2>&1 &
+    HTTP_PID=$!
+    sleep 1
+    kill -0 "$HTTP_PID" 2>/dev/null || fail "payload HTTP server failed to start"
+    log "payloads on host:${HTTP_PORT} (guest base http://10.0.2.2:${HTTP_PORT}/)"
+}
+stop_payload_server() { [[ -n "$HTTP_PID" ]] && kill "$HTTP_PID" 2>/dev/null || true; HTTP_PID=""; }
+guest_payload_url() { printf 'http://10.0.2.2:%s/%s\n' "$HTTP_PORT" "$1"; }
+
+# ----------------------------------------------------------------------------
+# QEMU
+# ----------------------------------------------------------------------------
+# _qemu <firmware> <timeout> <logfile> -- <extra args...>
+# Boots headless, serial -> logfile, exits on guest poweroff or timeout.
+_qemu() {
+    local firmware="$1" timeout_s="$2" logfile="$3"; shift 3
+    [[ "${1:-}" == "--" ]] && shift
+    local accel; accel="$(accel_args)"
+    local -a fw_args=()
+    local vars=""
+    if [[ "$firmware" == "uefi" ]]; then
+        local code tpl
+        code="$(find_ovmf_code)"; tpl="$(find_ovmf_vars_template)"
+        vars="$(mktemp --suffix=-OVMF_VARS.fd)"; cp "$tpl" "$vars"
+        fw_args=(-drive "if=pflash,format=raw,readonly=on,file=${code}"
+                 -drive "if=pflash,format=raw,file=${vars}")
+    fi
+    log "qemu (${firmware}, timeout ${timeout_s}s) -> $(basename "$logfile")"
+    # shellcheck disable=SC2086
+    timeout --foreground "$timeout_s" \
+        qemu-system-x86_64 $accel -m "$VM_MEM" -smp "$VM_SMP" "${fw_args[@]}" \
+            -netdev user,id=net0 -device virtio-net-pci,netdev=net0 \
+            -display none -no-reboot -serial "file:${logfile}" "$@" || true
+    [[ -n "$vars" ]] && rm -f "$vars"
+}
+
+# Boot the ISO (via extracted kernel) running a payload. Args:
+#   boot_iso_with_payload <firmware> <timeout> <logfile> <payload-file> [extra qemu args...]
+boot_iso_with_payload() {
+    local fw="$1" timeout_s="$2" logfile="$3" payload="$4"; shift 4
+    local iso label url tmpd
+    iso="$(find_iso)"
+    label="$(iso_label "$iso")"
+    tmpd="$(mktemp -d)"
+    extract_iso_boot "$iso" "$tmpd"
+    url="$(guest_payload_url "$payload")"
+    # cow_spacesize gives the live overlay room; console=ttyS0 sends boot
+    # messages to our captured serial; script= triggers the payload on tty1.
+    local cmdline="archisobasedir=arch archisolabel=${label} cow_spacesize=4G console=tty0 console=ttyS0,115200 script=${url}"
+    _qemu "$fw" "$timeout_s" "$logfile" -- \
+        -kernel "$KERNEL" -initrd "$INITRD" -append "$cmdline" \
+        -drive "file=${iso},media=cdrom,readonly=on" \
+        "$@"
+    rm -rf "$tmpd"
+}
+
+# Boot an installed disk image (no ISO). Args:
+#   boot_disk <firmware> <timeout> <logfile> <disk.qcow2> [extra qemu args...]
+boot_disk() {
+    local fw="$1" timeout_s="$2" logfile="$3" disk="$4"; shift 4
+    _qemu "$fw" "$timeout_s" "$logfile" -- \
+        -drive "file=${disk},if=virtio,format=qcow2" "$@"
+}
+
+expect_sentinel() {
+    local logfile="$1" pattern="$2" desc="${3:-$2}"
+    if grep -qa -- "$pattern" "$logfile"; then ok "found: ${desc}"; return 0; fi
+    log "----- last 40 lines of serial ($(basename "$logfile")) -----"
+    tail -n 40 "$logfile" >&2 || true
+    log "-----------------------------------------------------------"
+    fail "missing expected marker: ${desc}"
+}

--- a/scripts/test/payloads/install.sh
+++ b/scripts/test/payloads/install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Scripted install payload. Delivered to the live ISO via `script=<url>` and
+# run on tty1. It performs, headlessly, the same work Calamares does — wipe
+# the target disk, partition, copy the live root filesystem onto it, generate
+# fstab, build a normal initramfs, install GRUB, set up a serial login — then
+# powers off. Prints MIKA_INSTALL_OK to /dev/ttyS0 only if every step
+# succeeded (set -e aborts before the marker otherwise, which the harness
+# correctly reports as a failure).
+#
+# Target is the first virtio disk (/dev/vda) the harness attaches.
+#
+# This mirrors Calamares but is intentionally minimal; tune it against a real
+# build the first time through (initramfs hooks and bootloader are the usual
+# sticking points when converting an archiso live root into an installed one).
+
+set -euo pipefail
+exec >/dev/ttyS0 2>&1
+echo "MIKA_INSTALL_START"
+
+DISK="/dev/vda"
+SRC="/run/archiso/airootfs"   # pristine read-only squashfs (Calamares unpackfs source)
+
+# Wait for pacman-init etc. so the copied keyring/db is consistent.
+timeout 180 systemctl is-system-running --wait >/dev/null 2>&1 || true
+
+if [[ -d /sys/firmware/efi ]]; then FW="uefi"; else FW="bios"; fi
+echo "firmware=${FW} target=${DISK} source=${SRC}"
+[[ -d "$SRC" ]] || { echo "ERROR: live source $SRC not found"; exit 1; }
+
+echo "== partitioning =="
+sgdisk --zap-all "$DISK"
+if [[ "$FW" == "uefi" ]]; then
+    sgdisk -n1:0:+512M -t1:ef00 -c1:EFI  "$DISK"
+    sgdisk -n2:0:0     -t2:8300 -c2:ROOT "$DISK"
+    ESP="${DISK}1"; ROOT="${DISK}2"
+    mkfs.fat -F32 "$ESP"
+else
+    sgdisk -n1:0:+1M -t1:ef02 -c1:BIOS "$DISK"   # BIOS boot partition for GRUB
+    sgdisk -n2:0:0   -t2:8300 -c2:ROOT "$DISK"
+    ROOT="${DISK}2"
+fi
+mkfs.ext4 -F "$ROOT"
+
+echo "== mounting =="
+mount "$ROOT" /mnt
+if [[ "$FW" == "uefi" ]]; then
+    mkdir -p /mnt/boot
+    mount "$ESP" /mnt/boot
+fi
+
+echo "== copying live root filesystem =="
+# cp -a preserves attrs; the squashfs is already a clean installed-style tree.
+cp -a "${SRC}/." /mnt/
+
+echo "== fstab =="
+genfstab -U /mnt >> /mnt/etc/fstab
+
+echo "== de-archiso-ifying + bootloader =="
+arch-chroot /mnt /bin/bash -euo pipefail <<CHROOT
+# Remove live-only autologin/automation so the installed system shows a real
+# login prompt (the harness greps for "login:").
+rm -f /etc/systemd/system/getty@tty1.service.d/autologin.conf
+rm -f /root/.automated_script.sh /root/.zlogin
+
+# A normal initramfs (drop archiso hooks).
+cat > /etc/mkinitcpio.conf.d/mika.conf <<'MKI'
+HOOKS=(base udev autodetect microcode modconf kms keyboard keymap consolefont block filesystems fsck)
+MKI
+cat > /etc/mkinitcpio.d/linux.preset <<'PRE'
+ALL_kver="/boot/vmlinuz-linux"
+PRESETS=('default' 'fallback')
+default_image="/boot/initramfs-linux.img"
+fallback_image="/boot/initramfs-linux-fallback.img"
+fallback_options="-S autodetect"
+PRE
+mkinitcpio -P
+
+# Serial console so the harness can see the login prompt + kernel messages.
+sed -i 's|^GRUB_CMDLINE_LINUX_DEFAULT=.*|GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 console=tty0 console=ttyS0,115200"|' /etc/default/grub || true
+systemctl enable serial-getty@ttyS0.service
+systemctl enable NetworkManager.service 2>/dev/null || true
+
+if [[ -d /sys/firmware/efi ]]; then
+    grub-install --target=x86_64-efi --efi-directory=/boot --bootloader-id=GRUB --removable
+else
+    grub-install --target=i386-pc ${DISK}
+fi
+grub-mkconfig -o /boot/grub/grub.cfg
+
+# A known root password (test only).
+echo 'root:mika' | chpasswd
+CHROOT
+
+echo "== finishing =="
+sync
+umount -R /mnt
+
+echo "MIKA_INSTALL_OK"
+sync
+systemctl poweroff -i 2>/dev/null || poweroff -f

--- a/scripts/test/payloads/selftest.sh
+++ b/scripts/test/payloads/selftest.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Boot smoke-test payload. Delivered to the live ISO via `script=<url>` and
+# executed by /root/.automated_script.sh on tty1. Its job: prove the live
+# environment booted, then power off. All markers go to /dev/ttyS0 because
+# that is what the headless harness captures.
+
+exec >/dev/ttyS0 2>&1
+echo "MIKA_SELFTEST_START"
+
+# Give boot services a chance to settle (don't block forever if degraded).
+timeout 120 systemctl is-system-running --wait >/dev/null 2>&1 || true
+
+echo "kernel: $(uname -r)"
+echo "systemd state: $(systemctl is-system-running 2>/dev/null || true)"
+
+# The marker the harness greps for.
+echo "MIKA_BOOT_OK"
+
+sync
+systemctl poweroff -i 2>/dev/null || poweroff -f

--- a/scripts/test/run.sh
+++ b/scripts/test/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Interactive local boot — just open the ISO in a QEMU window to click around.
+# This is the "emulate it on my machine instead of a USB stick" shortcut.
+#
+# Usage:
+#   scripts/test/run.sh [bios|uefi]     (default: uefi)
+#   ISO=/path/to/x.iso scripts/test/run.sh
+#
+# Attaches a persistent 20G disk (scripts/test/.run-disk.qcow2) so you can do
+# a real manual Calamares install and keep it between runs.
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require qemu-system-x86_64 qemu-img
+
+FW="${1:-uefi}"
+ISO_PATH="$(find_iso)"
+DISK="${TEST_DIR}/.run-disk.qcow2"
+[[ -f "$DISK" ]] || qemu-img create -f qcow2 "$DISK" "$DISK_SIZE" >/dev/null
+
+accel="$(accel_args)"
+fw_args=()
+if [[ "$FW" == "uefi" ]]; then
+    code="$(find_ovmf_code)"; tpl="$(find_ovmf_vars_template)"
+    vars="${TEST_DIR}/.run-OVMF_VARS.fd"
+    [[ -f "$vars" ]] || cp "$tpl" "$vars"
+    fw_args=(-drive "if=pflash,format=raw,readonly=on,file=${code}"
+             -drive "if=pflash,format=raw,file=${vars}")
+fi
+
+log "interactive boot (${FW}) of ${ISO_PATH} — close the window to quit"
+# shellcheck disable=SC2086
+exec qemu-system-x86_64 $accel -m "$VM_MEM" -smp "$VM_SMP" "${fw_args[@]}" \
+    -drive "file=${ISO_PATH},media=cdrom,readonly=on" \
+    -drive "file=${DISK},if=virtio,format=qcow2" \
+    -netdev user,id=net0 -device virtio-net-pci,netdev=net0 \
+    -boot d


### PR DESCRIPTION
Adds a runner-agnostic (bash + qemu) harness under scripts/test/ to emulate
the ISO instead of flashing a USB and installing on a test laptop:

- boot-test.sh: headless boot smoke test in BIOS and UEFI, using the ISO's
  extracted kernel and the existing script= cmdline hook to run a payload that
  signals MIKA_BOOT_OK over the serial console.
- install-test.sh: scripted install onto a blank qcow2 (modeled on Calamares'
  unpackfs flow), then boots the installed disk and asserts a login prompt.
- payloads/ delivered to the guest over HTTP (10.0.2.2) so no test code is
  baked into the production ISO.
- run.sh: interactive local boot for manual poke-around.
- lib.sh: shared helpers (ISO/OVMF discovery, KVM detection, QEMU runner).
- .github/workflows/iso-test.yml: manual-trigger CI starting point.

KVM is used when available and falls back to TCG otherwise, so it runs the
same locally and in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a QEMU-based ISO test harness with automated boot and scripted install checks for BIOS and UEFI, plus payloads that signal pass/fail via serial output.
  * Added an interactive local QEMU runner for manual verification.

* **Chores**
  * Added a manual CI workflow to build and verify ISOs and upload artifacts (ISO artifacts preserved on failure).

* **Documentation**
  * Added comprehensive test harness docs and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->